### PR TITLE
Integrate AWS IoT MQTT client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@
 
 # macOS system files
 .DS_Store
+
+# AWS IoT certificates
+aws_root_ca.pem
+client.crt
+client.key

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,2 +1,6 @@
-idf_component_register(SRCS "main.c"
-                    INCLUDE_DIRS ".")
+idf_component_register(
+    SRCS "main.c"
+    INCLUDE_DIRS "."
+    REQUIRES esp_wifi nvs_flash mqtt esp_netif
+    EMBED_FILES "aws_root_ca.pem" "client.crt" "client.key"
+)

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -1,0 +1,9 @@
+menu "WiFi Configuration"
+    config WIFI_SSID
+        string "WiFi SSID"
+        default "your-ssid"
+
+    config WIFI_PASSWORD
+        string "WiFi Password"
+        default "your-password"
+endmenu

--- a/main/main.c
+++ b/main/main.c
@@ -1,14 +1,23 @@
 #include <stdio.h>
+#include <string.h>
+
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "freertos/event_groups.h"
+
 #include "driver/ledc.h"
 #include "driver/gpio.h"
 #include "driver/rmt_encoder.h"
 #include "driver/rmt_common.h"
 #include "driver/rmt_rx.h"
 #include "driver/rmt_types.h"
+
+#include "esp_event.h"
 #include "esp_log.h"
-#include <string.h>
+#include "nvs_flash.h"
+#include "esp_netif.h"
+#include "esp_wifi.h"
+#include "mqtt_client.h"
 
 #define SERVO_GPIO      26    
 #define IR_GPIO         14      
@@ -21,6 +30,111 @@
 #define IR_UNLOCK_CODE  0xFFA25D // Remote code for unlocking the lock
 
 static const char *TAG = "ESP32-LOCK";
+
+#define WIFI_SSID CONFIG_WIFI_SSID
+#define WIFI_PASS CONFIG_WIFI_PASSWORD
+
+#define AWS_ENDPOINT "asczbrce6nb95-ats.iot.us-east-2.amazonaws.com"
+#define CLIENT_ID "esp32LockClient"
+#define MQTT_PUB_TOPIC "esp32/lock/state"
+#define MQTT_SUB_TOPIC "esp32/lock/control"
+
+extern const uint8_t aws_root_ca_pem_start[] asm("_binary_aws_root_ca_pem_start");
+extern const uint8_t aws_root_ca_pem_end[]   asm("_binary_aws_root_ca_pem_end");
+extern const uint8_t client_crt_start[] asm("_binary_client_crt_start");
+extern const uint8_t client_crt_end[]   asm("_binary_client_crt_end");
+extern const uint8_t client_key_start[] asm("_binary_client_key_start");
+extern const uint8_t client_key_end[]   asm("_binary_client_key_end");
+
+static EventGroupHandle_t wifi_event_group;
+#define WIFI_CONNECTED_BIT BIT0
+
+static esp_mqtt_client_handle_t mqtt_client = NULL;
+
+static void publish_state(bool unlocked);
+
+static void wifi_event_handler(void *arg, esp_event_base_t event_base,
+                               int32_t event_id, void *event_data)
+{
+    if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
+        esp_wifi_connect();
+    } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
+        esp_wifi_connect();
+    } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
+        xEventGroupSetBits(wifi_event_group, WIFI_CONNECTED_BIT);
+    }
+}
+
+static void wifi_init(void)
+{
+    wifi_event_group = xEventGroupCreate();
+    ESP_ERROR_CHECK(esp_netif_init());
+    ESP_ERROR_CHECK(esp_event_loop_create_default());
+    esp_netif_create_default_wifi_sta();
+
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+
+    ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, ESP_EVENT_ANY_ID, &wifi_event_handler, NULL));
+    ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP, &wifi_event_handler, NULL));
+
+    wifi_config_t wifi_config = {
+        .sta = {
+            .ssid = WIFI_SSID,
+            .password = WIFI_PASS,
+            .threshold.authmode = WIFI_AUTH_WPA2_PSK,
+        },
+    };
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
+    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
+    ESP_ERROR_CHECK(esp_wifi_start());
+
+    xEventGroupWaitBits(wifi_event_group, WIFI_CONNECTED_BIT, pdFALSE, pdFALSE, portMAX_DELAY);
+}
+
+static esp_err_t mqtt_event_handler_cb(esp_mqtt_event_handle_t event)
+{
+    switch (event->event_id) {
+    case MQTT_EVENT_CONNECTED:
+        esp_mqtt_client_subscribe(event->client, MQTT_SUB_TOPIC, 1);
+        break;
+    case MQTT_EVENT_DATA:
+        if (strncmp(event->topic, MQTT_SUB_TOPIC, event->topic_len) == 0) {
+            if (strncmp(event->data, "UNLOCK", event->data_len) == 0) {
+                publish_state(true);
+            } else if (strncmp(event->data, "LOCK", event->data_len) == 0) {
+                publish_state(false);
+            }
+        }
+        break;
+    default:
+        break;
+    }
+    return ESP_OK;
+}
+
+static void mqtt_init(void)
+{
+    esp_mqtt_client_config_t mqtt_cfg = {
+        .uri = "mqtts://"AWS_ENDPOINT,
+        .client_id = CLIENT_ID,
+        .cert_pem = (const char *)aws_root_ca_pem_start,
+        .client_cert_pem = (const char *)client_crt_start,
+        .client_key_pem = (const char *)client_key_start,
+    };
+
+    mqtt_client = esp_mqtt_client_init(&mqtt_cfg);
+    esp_mqtt_client_register_event(mqtt_client, ESP_EVENT_ANY_ID, mqtt_event_handler_cb, NULL);
+    esp_mqtt_client_start(mqtt_client);
+}
+
+static void publish_state(bool unlocked)
+{
+    if (mqtt_client) {
+        const char *msg = unlocked ? "UNLOCKED" : "LOCKED";
+        esp_mqtt_client_publish(mqtt_client, MQTT_PUB_TOPIC, msg, 0, 1, 0);
+    }
+}
 
 void set_servo_us(uint32_t microseconds) {
     uint32_t max_duty = (1 << 14) - 1; 
@@ -109,9 +223,11 @@ void ir_task(void *pvParameter) {
                     if (unlocked) {
                         set_servo_us(SERVO_UNLOCKED);
                         ESP_LOGI(TAG, "Lock state changed to: UNLOCKED");
+                        publish_state(true);
                     } else {
                         set_servo_us(SERVO_LOCKED);
                         ESP_LOGI(TAG, "Lock state changed to: LOCKED");
+                        publish_state(false);
                     }
                 } else {
                     ESP_LOGI(TAG, "Unknown IR code received");
@@ -128,6 +244,10 @@ void ir_task(void *pvParameter) {
 }
 
 void app_main(void) {
+    ESP_ERROR_CHECK(nvs_flash_init());
+    wifi_init();
+    mqtt_init();
+
     servo_init();
     xTaskCreate(ir_task, "ir_task", 4096, NULL, 5, NULL);
 }


### PR DESCRIPTION
## Summary
- add WiFi config options for connecting to AWS IoT
- embed AWS certificates and require WiFi/MQTT components
- connect to WiFi and AWS IoT MQTT in `app_main`
- publish lock state to AWS when IR command toggles
- ignore certificate files

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d9b8636483298685488bc7dfa924